### PR TITLE
add user/group/mode parameter to custom types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1204,6 +1204,18 @@ The basic property that the resource should be in.
 
 Default value: `present`
 
+##### `group`
+
+group of the file
+
+##### `mode`
+
+mode of the file
+
+##### `owner`
+
+owner of the file
+
 #### Parameters
 
 The following parameters are available in the `dhparam` type.
@@ -1251,6 +1263,18 @@ Valid values: `present`, `absent`
 The basic property that the resource should be in.
 
 Default value: `present`
+
+##### `group`
+
+group of the file
+
+##### `mode`
+
+mode of the file
+
+##### `owner`
+
+owner of the file
 
 #### Parameters
 
@@ -1313,6 +1337,18 @@ Valid values: `present`, `absent`
 The basic property that the resource should be in.
 
 Default value: `present`
+
+##### `group`
+
+group of the file
+
+##### `mode`
+
+mode of the file
+
+##### `owner`
+
+owner of the file
 
 #### Parameters
 
@@ -1407,6 +1443,18 @@ Valid values: `present`, `absent`
 The basic property that the resource should be in.
 
 Default value: `present`
+
+##### `group`
+
+group of the file
+
+##### `mode`
+
+mode of the file
+
+##### `owner`
+
+owner of the file
 
 #### Parameters
 

--- a/lib/puppet/provider/dhparam/openssl.rb
+++ b/lib/puppet/provider/dhparam/openssl.rb
@@ -5,7 +5,7 @@ require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 
 Puppet::Type.type(:dhparam).provide(
   :openssl,
-  parent: Puppet::Provider::Openssl,
+  parent: Puppet::Provider::Openssl
 ) do
   desc 'Manages dhparam files with OpenSSL'
 

--- a/lib/puppet/provider/dhparam/openssl.rb
+++ b/lib/puppet/provider/dhparam/openssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 
 Puppet::Type.type(:dhparam).provide(
   :openssl,

--- a/lib/puppet/provider/dhparam/openssl.rb
+++ b/lib/puppet/provider/dhparam/openssl.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'pathname'
-Puppet::Type.type(:dhparam).provide(:openssl) do
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+
+Puppet::Type.type(:dhparam).provide(
+  :openssl,
+  parent: Puppet::Provider::Openssl,
+) do
   desc 'Manages dhparam files with OpenSSL'
 
   commands openssl: 'openssl'
@@ -19,6 +24,7 @@ Puppet::Type.type(:dhparam).provide(:openssl) do
     options.insert(1, '-dsaparam') if resource[:fastmode]
 
     openssl options
+    set_file_perm(resource[:path], resource[:owner], resource[:group], resource[:mode])
   end
 
   def destroy

--- a/lib/puppet/provider/openssl.rb
+++ b/lib/puppet/provider/openssl.rb
@@ -13,7 +13,7 @@ class Puppet::Provider::Openssl < Puppet::Provider
   end
 
   def owner=(should)
-    File.send(:chown, uid(should), nil, resource[:path])
+    File.chown(uid(should), nil, resource[:path])
   rescue => detail
     raise Puppet::Error, _("Failed to set owner to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
   end
@@ -27,7 +27,7 @@ class Puppet::Provider::Openssl < Puppet::Provider
   end
 
   def group=(should)
-    File.send(:chown, nil, gid(should), resource[:path])
+    File.chown(nil, gid(should), resource[:path])
   rescue => detail
     raise Puppet::Error, _("Failed to set group to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
   end
@@ -47,8 +47,8 @@ class Puppet::Provider::Openssl < Puppet::Provider
   end
 
   def set_file_perm(filename, owner = nil, group = nil, mode = nil)
-    File.send(:chown, uid(owner), nil, filename) if owner
-    File.send(:chown, nil, gid(group), filename) if group
+    File.chown(uid(owner), nil, resource[:path]) if owner
+    File.chown(nil, gid(group), resource[:path]) if group
     File.chmod(Integer('0' + mode), filename) if mode
   end
 end

--- a/lib/puppet/provider/openssl.rb
+++ b/lib/puppet/provider/openssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'etc'
 
 # class to use in openssl providers to handle file permission (mode, group and owner)
@@ -14,8 +16,8 @@ class Puppet::Provider::Openssl < Puppet::Provider
 
   def owner=(should)
     File.chown(uid(should), nil, resource[:path])
-  rescue => detail
-    raise Puppet::Error, _("Failed to set owner to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
+  rescue StandardError => e
+    raise Puppet::Error, _("Failed to set owner to '#{should}': #{e}"), detail.backtrace
   end
 
   def group
@@ -28,14 +30,14 @@ class Puppet::Provider::Openssl < Puppet::Provider
 
   def group=(should)
     File.chown(nil, gid(should), resource[:path])
-  rescue => detail
-    raise Puppet::Error, _("Failed to set group to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
+  rescue StandardError => e
+    raise Puppet::Error, _("Failed to set group to '#{should}': #{e}"), detail.backtrace
   end
 
   # Return the mode as an octal string, not as an integer.
   def mode
     if File.exist?(@resource[:path])
-      '0%o' % (File.stat(@resource[:path]).mode & 0o07777)
+      format('0%o', (File.stat(@resource[:path]).mode & 0o07777))
     else
       :absent
     end
@@ -43,12 +45,12 @@ class Puppet::Provider::Openssl < Puppet::Provider
 
   # Set the file mode, converting from a string to an integer.
   def mode=(should)
-    File.chmod(Integer('0' + should), @resource[:path])
+    File.chmod(Integer("0#{should}"), @resource[:path])
   end
 
   def set_file_perm(filename, owner = nil, group = nil, mode = nil)
     File.chown(uid(owner), nil, resource[:path]) if owner
     File.chown(nil, gid(group), resource[:path]) if group
-    File.chmod(Integer('0' + mode), filename) if mode
+    File.chmod(Integer("0#{mode}"), filename) if mode
   end
 end

--- a/lib/puppet/provider/openssl.rb
+++ b/lib/puppet/provider/openssl.rb
@@ -1,0 +1,54 @@
+require 'etc'
+
+# class to use in openssl providers to handle file permission (mode, group and owner)
+class Puppet::Provider::Openssl < Puppet::Provider
+  include Puppet::Util::POSIX
+
+  def owner
+    if File.exist?(@resource[:path])
+      Etc.getpwuid(File.stat(@resource[:path]).uid).name
+    else
+      :absent
+    end
+  end
+
+  def owner=(should)
+    File.send(:chown, uid(should), nil, resource[:path])
+  rescue => detail
+    raise Puppet::Error, _("Failed to set owner to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
+  end
+
+  def group
+    if File.exist?(@resource[:path])
+      Etc.getgrgid(File.stat(@resource[:path]).gid).name
+    else
+      :absent
+    end
+  end
+
+  def group=(should)
+    File.send(:chown, nil, gid(should), resource[:path])
+  rescue => detail
+    raise Puppet::Error, _("Failed to set group to '%{should}': %{detail}") % { should: should, detail: detail }, detail.backtrace
+  end
+
+  # Return the mode as an octal string, not as an integer.
+  def mode
+    if File.exist?(@resource[:path])
+      '0%o' % (File.stat(@resource[:path]).mode & 0o07777)
+    else
+      :absent
+    end
+  end
+
+  # Set the file mode, converting from a string to an integer.
+  def mode=(should)
+    File.chmod(Integer('0' + should), @resource[:path])
+  end
+
+  def set_file_perm(filename, owner = nil, group = nil, mode = nil)
+    File.send(:chown, uid(owner), nil, filename) if owner
+    File.send(:chown, nil, gid(group), filename) if group
+    File.chmod(Integer('0' + mode), filename) if mode
+  end
+end

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -2,7 +2,11 @@
 
 require 'pathname'
 require 'openssl'
-Puppet::Type.type(:ssl_pkey).provide(:openssl) do
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+Puppet::Type.type(:ssl_pkey).provide(
+  :openssl,
+  parent: Puppet::Provider::Openssl,
+) do
   desc 'Manages private keys with OpenSSL'
 
   def self.dirname(resource)
@@ -38,6 +42,7 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
     key = self.class.generate_key(resource)
     pem = self.class.to_pem(resource, key)
     File.write(resource[:path], pem)
+    set_file_perm(resource[:path], resource[:owner], resource[:group], resource[:mode])
   end
 
   def destroy

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -2,7 +2,7 @@
 
 require 'pathname'
 require 'openssl'
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:ssl_pkey).provide(
   :openssl,
   parent: Puppet::Provider::Openssl,

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -5,7 +5,7 @@ require 'openssl'
 require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:ssl_pkey).provide(
   :openssl,
-  parent: Puppet::Provider::Openssl,
+  parent: Puppet::Provider::Openssl
 ) do
   desc 'Manages private keys with OpenSSL'
 

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -4,7 +4,7 @@ require 'pathname'
 require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:x509_cert).provide(
   :openssl,
-  parent: Puppet::Provider::Openssl,
+  parent: Puppet::Provider::Openssl
 ) do
   desc 'Manages certificates with OpenSSL'
 

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:x509_cert).provide(
   :openssl,
   parent: Puppet::Provider::Openssl,

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'pathname'
-Puppet::Type.type(:x509_cert).provide(:openssl) do
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+Puppet::Type.type(:x509_cert).provide(
+  :openssl,
+  parent: Puppet::Provider::Openssl,
+) do
   desc 'Manages certificates with OpenSSL'
 
   commands openssl: 'openssl'
@@ -103,6 +107,7 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
     # openssl(options) doesn't work because it's impossible to pass an env
     # https://github.com/puppetlabs/puppet/issues/9493
     execute([command('openssl')] + options, { failonfail: true, combine: true, custom_environment: env })
+    set_file_perm(resource[:path], resource[:owner], resource[:group], resource[:mode])
   end
 
   def destroy

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -4,7 +4,7 @@ require 'pathname'
 require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:x509_request).provide(
   :openssl,
-  parent: Puppet::Provider::Openssl,
+  parent: Puppet::Provider::Openssl
 ) do
   desc 'Manages certificate signing requests with OpenSSL'
 

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+require File.join(__dir__, '..', '..', '..', 'puppet/provider/openssl')
 Puppet::Type.type(:x509_request).provide(
   :openssl,
   parent: Puppet::Provider::Openssl,

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'pathname'
-Puppet::Type.type(:x509_request).provide(:openssl) do
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet/provider/openssl')
+Puppet::Type.type(:x509_request).provide(
+  :openssl,
+  parent: Puppet::Provider::Openssl,
+) do
   desc 'Manages certificate signing requests with OpenSSL'
 
   commands openssl: 'openssl'
@@ -45,6 +49,8 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
     # openssl(options) doesn't work because it's impossible to pass an env
     # https://github.com/puppetlabs/puppet/issues/9493
     execute([command('openssl')] + options, { failonfail: true, combine: true, custom_environment: env })
+
+    set_file_perm(resource[:path], resource[:owner], resource[:group], resource[:mode])
   end
 
   def destroy

--- a/lib/puppet/type/dhparam.rb
+++ b/lib/puppet/type/dhparam.rb
@@ -35,4 +35,31 @@ Puppet::Type.newtype(:dhparam) do
   autorequire(:file) do
     Pathname.new(self[:path]).parent.to_s
   end
+
+  newproperty(:owner) do
+    desc 'owner of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid user name' % value
+      end
+    end
+  end
+
+  newproperty(:group) do
+    desc 'group of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid group name' % value
+      end
+    end
+  end
+
+  newproperty(:mode) do
+    desc 'mode of the file'
+    validate do |value|
+      unless value =~ %r{^0\d\d\d$}
+        raise ArgumentError, '%s is not a valid file mode' % value
+      end
+    end
+  end
 end

--- a/lib/puppet/type/dhparam.rb
+++ b/lib/puppet/type/dhparam.rb
@@ -39,14 +39,14 @@ Puppet::Type.newtype(:dhparam) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+$}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+$}
     end
   end
 

--- a/lib/puppet/type/dhparam.rb
+++ b/lib/puppet/type/dhparam.rb
@@ -39,27 +39,21 @@ Puppet::Type.newtype(:dhparam) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid user name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid group name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:mode) do
     desc 'mode of the file'
     validate do |value|
-      unless value =~ %r{^0\d\d\d$}
-        raise ArgumentError, '%s is not a valid file mode' % value
-      end
+      raise ArgumentError, "#{value} is not a valid file mode" unless value =~ %r{^0\d\d\d$}
     end
   end
 end

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -46,27 +46,21 @@ Puppet::Type.newtype(:ssl_pkey) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid user name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid group name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:mode) do
     desc 'mode of the file'
     validate do |value|
-      unless value =~ %r{^0\d\d\d$}
-        raise ArgumentError, '%s is not a valid file mode' % value
-      end
+      raise ArgumentError, "#{value} is not a valid file mode" unless value =~ %r{^0\d\d\d$}
     end
   end
 end

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -46,14 +46,14 @@ Puppet::Type.newtype(:ssl_pkey) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+$}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+$}
     end
   end
 

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -42,4 +42,31 @@ Puppet::Type.newtype(:ssl_pkey) do
   autorequire(:file) do
     Pathname.new(self[:path]).parent.to_s
   end
+
+  newproperty(:owner) do
+    desc 'owner of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid user name' % value
+      end
+    end
+  end
+
+  newproperty(:group) do
+    desc 'group of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid group name' % value
+      end
+    end
+  end
+
+  newproperty(:mode) do
+    desc 'mode of the file'
+    validate do |value|
+      unless value =~ %r{^0\d\d\d$}
+        raise ArgumentError, '%s is not a valid file mode' % value
+      end
+    end
+  end
 end

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -76,6 +76,33 @@ Puppet::Type.newtype(:x509_cert) do
     desc 'The optional CA key password'
   end
 
+  newproperty(:owner) do
+    desc 'owner of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid user name' % value
+      end
+    end
+  end
+
+  newproperty(:group) do
+    desc 'group of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid group name' % value
+      end
+    end
+  end
+
+  newproperty(:mode) do
+    desc 'mode of the file'
+    validate do |value|
+      unless value =~ %r{^0\d\d\d$}
+        raise ArgumentError, '%s is not a valid file mode' % value
+      end
+    end
+  end
+
   autorequire(:file) do
     self[:template]
   end

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -79,14 +79,14 @@ Puppet::Type.newtype(:x509_cert) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+$}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+$}
     end
   end
 

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -79,27 +79,21 @@ Puppet::Type.newtype(:x509_cert) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid user name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid group name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:mode) do
     desc 'mode of the file'
     validate do |value|
-      unless value =~ %r{^0\d\d\d$}
-        raise ArgumentError, '%s is not a valid file mode' % value
-      end
+      raise ArgumentError, "#{value} is not a valid file mode" unless value =~ %r{^0\d\d\d$}
     end
   end
 

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -54,6 +54,33 @@ Puppet::Type.newtype(:x509_request) do
     defaultto true
   end
 
+  newproperty(:owner) do
+    desc 'owner of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid user name' % value
+      end
+    end
+  end
+
+  newproperty(:group) do
+    desc 'group of the file'
+    validate do |value|
+      unless value =~ %r{^\w+}
+        raise ArgumentError, '%s is not a valid group name' % value
+      end
+    end
+  end
+
+  newproperty(:mode) do
+    desc 'mode of the file'
+    validate do |value|
+      unless value =~ %r{^0\d\d\d$}
+        raise ArgumentError, '%s is not a valid file mode' % value
+      end
+    end
+  end
+
   autorequire(:x509_cert) do
     path = Pathname.new(self[:private_key])
     "#{path.dirname}/#{path.basename(path.extname)}"

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -57,27 +57,21 @@ Puppet::Type.newtype(:x509_request) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid user name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      unless value =~ %r{^\w+}
-        raise ArgumentError, '%s is not a valid group name' % value
-      end
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
     end
   end
 
   newproperty(:mode) do
     desc 'mode of the file'
     validate do |value|
-      unless value =~ %r{^0\d\d\d$}
-        raise ArgumentError, '%s is not a valid file mode' % value
-      end
+      raise ArgumentError, "#{value} is not a valid file mode" unless value =~ %r{^0\d\d\d$}
     end
   end
 

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -57,14 +57,14 @@ Puppet::Type.newtype(:x509_request) do
   newproperty(:owner) do
     desc 'owner of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid user name" unless value =~ %r{^\w+$}
     end
   end
 
   newproperty(:group) do
     desc 'group of the file'
     validate do |value|
-      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+}
+      raise ArgumentError, "#{value} is not a valid group name" unless value =~ %r{^\w+$}
     end
   end
 

--- a/spec/unit/puppet/type/dhparam_spec.rb
+++ b/spec/unit/puppet/type/dhparam_spec.rb
@@ -44,13 +44,31 @@ describe Puppet::Type.type(:dhparam) do
     expect(resource[:mode]).to eq('0700')
   end
 
+  it 'does not accept numeric mode' do
+    expect do
+      resource[:mode] = '700'
+    end.to raise_error(Puppet::Error, %r{700 is not a valid file mode})
+  end
+
   it 'accepts owner' do
     resource[:owner] = 'someone'
     expect(resource[:owner]).to eq('someone')
   end
 
+  it 'does not accept bad owner' do
+    expect do
+      resource[:owner] = 'someone else'
+    end.to raise_error(Puppet::Error, %r{someone else is not a valid user name})
+  end
+
   it 'accepts group' do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
+  end
+
+  it 'does not accept bad group group' do
+    expect do
+      resource[:group] = 'party crasher'
+    end.to raise_error(Puppet::Error, %r{party crasher is not a valid group name})
   end
 end

--- a/spec/unit/puppet/type/dhparam_spec.rb
+++ b/spec/unit/puppet/type/dhparam_spec.rb
@@ -38,4 +38,20 @@ describe Puppet::Type.type(:dhparam) do
       resource[:size] = 1.5
     end.to raise_error(Puppet::Error, %r{Size must be a positive integer: 1.5})
   end
+
+  it 'accepts mode' do
+    resource[:mode] = '0700'
+    expect(resource[:mode]).to eq('0700')
+  end
+
+  it 'accepts owner' do
+    resource[:owner] = 'someone'
+    expect(resource[:owner]).to eq('someone')
+  end
+
+  it 'accepts group' do
+    resource[:group] = 'party'
+    expect(resource[:group]).to eq('party')
+  end
+
 end

--- a/spec/unit/puppet/type/dhparam_spec.rb
+++ b/spec/unit/puppet/type/dhparam_spec.rb
@@ -53,5 +53,4 @@ describe Puppet::Type.type(:dhparam) do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
   end
-
 end

--- a/spec/unit/puppet/type/ssl_pkey_spec.rb
+++ b/spec/unit/puppet/type/ssl_pkey_spec.rb
@@ -49,4 +49,20 @@ describe Puppet::Type.type(:ssl_pkey) do
     resource[:password] = 'foox2$bar'
     expect(resource[:password]).to eq('foox2$bar')
   end
+
+  it 'accepts mode' do
+    resource[:mode] = '0700'
+    expect(resource[:mode]).to eq('0700')
+  end
+
+  it 'accepts owner' do
+    resource[:owner] = 'someone'
+    expect(resource[:owner]).to eq('someone')
+  end
+
+  it 'accepts group' do
+    resource[:group] = 'party'
+    expect(resource[:group]).to eq('party')
+  end
+
 end

--- a/spec/unit/puppet/type/ssl_pkey_spec.rb
+++ b/spec/unit/puppet/type/ssl_pkey_spec.rb
@@ -64,5 +64,4 @@ describe Puppet::Type.type(:ssl_pkey) do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
   end
-
 end

--- a/spec/unit/puppet/type/ssl_pkey_spec.rb
+++ b/spec/unit/puppet/type/ssl_pkey_spec.rb
@@ -55,13 +55,31 @@ describe Puppet::Type.type(:ssl_pkey) do
     expect(resource[:mode]).to eq('0700')
   end
 
+  it 'does not accept numeric mode' do
+    expect do
+      resource[:mode] = '700'
+    end.to raise_error(Puppet::Error, %r{700 is not a valid file mode})
+  end
+
   it 'accepts owner' do
     resource[:owner] = 'someone'
     expect(resource[:owner]).to eq('someone')
   end
 
+  it 'does not accept bad owner' do
+    expect do
+      resource[:owner] = 'someone else'
+    end.to raise_error(Puppet::Error, %r{someone else is not a valid user name})
+  end
+
   it 'accepts group' do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
+  end
+
+  it 'does not accept bad group group' do
+    expect do
+      resource[:group] = 'party crasher'
+    end.to raise_error(Puppet::Error, %r{party crasher is not a valid group name})
   end
 end

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -69,4 +69,20 @@ describe Puppet::Type.type(:x509_cert) do
     resource[:csr] = '/tmp/foo.csr'
     expect(resource[:csr]).to eq('/tmp/foo.csr')
   end
+
+  it 'accepts mode' do
+    resource[:mode] = '0700'
+    expect(resource[:mode]).to eq('0700')
+  end
+
+  it 'accepts owner' do
+    resource[:owner] = 'someone'
+    expect(resource[:owner]).to eq('someone')
+  end
+
+  it 'accepts group' do
+    resource[:group] = 'party'
+    expect(resource[:group]).to eq('party')
+  end
+
 end

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -84,5 +84,4 @@ describe Puppet::Type.type(:x509_cert) do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
   end
-
 end

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -75,13 +75,31 @@ describe Puppet::Type.type(:x509_cert) do
     expect(resource[:mode]).to eq('0700')
   end
 
+  it 'does not accept numeric mode' do
+    expect do
+      resource[:mode] = '700'
+    end.to raise_error(Puppet::Error, %r{700 is not a valid file mode})
+  end
+
   it 'accepts owner' do
     resource[:owner] = 'someone'
     expect(resource[:owner]).to eq('someone')
   end
 
+  it 'does not accept bad owner' do
+    expect do
+      resource[:owner] = 'someone else'
+    end.to raise_error(Puppet::Error, %r{someone else is not a valid user name})
+  end
+
   it 'accepts group' do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
+  end
+
+  it 'does not accept bad group group' do
+    expect do
+      resource[:group] = 'party crasher'
+    end.to raise_error(Puppet::Error, %r{party crasher is not a valid group name})
   end
 end

--- a/spec/unit/puppet/type/x509_request_spec.rb
+++ b/spec/unit/puppet/type/x509_request_spec.rb
@@ -59,13 +59,31 @@ describe Puppet::Type.type(:x509_request) do
     expect(resource[:mode]).to eq('0700')
   end
 
+  it 'does not accept numeric mode' do
+    expect do
+      resource[:mode] = '700'
+    end.to raise_error(Puppet::Error, %r{700 is not a valid file mode})
+  end
+
   it 'accepts owner' do
     resource[:owner] = 'someone'
     expect(resource[:owner]).to eq('someone')
   end
 
+  it 'does not accept bad owner' do
+    expect do
+      resource[:owner] = 'someone else'
+    end.to raise_error(Puppet::Error, %r{someone else is not a valid user name})
+  end
+
   it 'accepts group' do
     resource[:group] = 'party'
     expect(resource[:group]).to eq('party')
+  end
+
+  it 'does not accept bad group group' do
+    expect do
+      resource[:group] = 'party crasher'
+    end.to raise_error(Puppet::Error, %r{party crasher is not a valid group name})
   end
 end

--- a/spec/unit/puppet/type/x509_request_spec.rb
+++ b/spec/unit/puppet/type/x509_request_spec.rb
@@ -53,4 +53,19 @@ describe Puppet::Type.type(:x509_request) do
       resource[:force] = :foo
     end.to raise_error(Puppet::Error, %r{Invalid value :foo})
   end
+
+  it 'accepts mode' do
+    resource[:mode] = '0700'
+    expect(resource[:mode]).to eq('0700')
+  end
+
+  it 'accepts owner' do
+    resource[:owner] = 'someone'
+    expect(resource[:owner]).to eq('someone')
+  end
+
+  it 'accepts group' do
+    resource[:group] = 'party'
+    expect(resource[:group]).to eq('party')
+  end
 end


### PR DESCRIPTION
This adds the possibility to directly specify user/group and mode for key, request, cert and dh.
In a second step the manifests could be simplified (no need for file resources setting permissions).