### PR TITLE
fix openssl_version on EL8 OpenSSL 1.1.1k

### DIFF
--- a/lib/facter/openssl_version.rb
+++ b/lib/facter/openssl_version.rb
@@ -4,7 +4,7 @@ Facter.add(:openssl_version) do
   setcode do
     if Facter::Util::Resolution.which('openssl')
       openssl_version = Facter::Util::Resolution.exec('openssl version 2>&1')
-      matches = %r{^OpenSSL ([\w.\-]+)( FIPS)?( +)([\d.]+)( +)([\w.]+)( +)([\d.]+)}.match(openssl_version)
+      matches = %r{^OpenSSL ([\w.\-]+)(\s+FIPS)?( +)([\d.]+)( +)([\w.]+)( +)([\d.]+)}.match(openssl_version)
       matches[1] if matches
     end
   end

--- a/spec/unit/openssl_version_spec.rb
+++ b/spec/unit/openssl_version_spec.rb
@@ -75,6 +75,19 @@ describe Facter.fact(:openssl_version) do
           }
         end
       end
+
+      describe 'openssl_version rhel8 latest' do
+        context 'with value' do
+          before do
+            allow(Facter::Util::Resolution).to receive(:which).with('openssl').and_return(true)
+            allow(Facter::Util::Resolution).to receive(:exec).with('openssl version 2>&1').and_return('OpenSSL 1.1.1k  FIPS 25 Mar 2021')
+          end
+
+          it {
+            expect(Facter.value(:openssl_version)).to eq('1.1.1k')
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As described in #134, the custom fact openssl_version does not work on EL8 OpenSSL 1.1.1k.
There is a subtle change in the output of `openssl version`: there are two spaces instead of one after the version number...