### PR TITLE
Enlarge key size based on new security requirement

### DIFF
--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -108,7 +108,7 @@ define openssl::certificate::x509 (
   Optional[Stdlib::Absolutepath]     $crt = undef,
   Optional[Stdlib::Absolutepath]     $csr = undef,
   Optional[Stdlib::Absolutepath]     $key = undef,
-  Integer                            $key_size = 2048,
+  Integer                            $key_size = 3072,
   Variant[String, Integer]           $owner = 'root',
   Variant[String, Integer]           $group = 'root',
   Optional[Variant[String, Integer]] $key_owner = undef,


### PR DESCRIPTION
#### Enlarge default key size for x509 certificate

As mentioned here : 5.3.1 Key Length
https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf
"The length of the modulus n should be at least 2000 bits for a period of use until 2023 and at least 3000 bits if used beyond 2023."