### PR TITLE
Allow cert_file to download certificates via https

### DIFF
--- a/lib/puppet/provider/cert_file/posix.rb
+++ b/lib/puppet/provider/cert_file/posix.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:cert_file).provide :posix do
 
   def remotecert
     cert = nil
-    Puppet.runtime[:http].get(URI(resource[:source])) do |response|
+    Puppet.runtime[:http].get(URI(resource[:source]), options: { include_system_store: true }) do |response|
       if response.success?
         response.read_body do |data|
           cert = OpenSSL::X509::Certificate.new(data)


### PR DESCRIPTION

#### Pull Request (PR) description
Accept server certificates signed by trusted third-parties when receiving remote certificates via https.

#### This Pull Request (PR) fixes the following issues
When getting a remote certificate via https, by default the http client trusts the PuppetCA only, thus downloading files from a server using certificates signed by a third-party would fail. This patch allows the Puppet HTTP client to trust a server using a certificate signed by any CA trusted by the system.