### PR TITLE
templates/cert.cnf.erb should use @, not $

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -94,7 +94,7 @@ class openssl::configs (
           extendedkeyusages => $extendedkeyusages,
           keyusages         => $keyusages,
           subjectaltnames   => $subjectaltnames,
-        } + delete($vals,['ensure', 'owner', 'group', 'mode']),
+        } + delete($vals, ['ensure', 'owner', 'group', 'mode']),
       ),
       tag     => 'openssl-configs',
     }

--- a/templates/cert.cnf.erb
+++ b/templates/cert.cnf.erb
@@ -14,7 +14,7 @@ default_md              = sha256
 default_keyfile         = privkey.pem
 distinguished_name      = req_distinguished_name
 prompt                  = no
-<% if $req_ext == true -%>
+<% if @req_ext == true -%>
 req_extensions          = req_ext
 <% end -%>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Fixing ERB syntax in templates/cert.cnf.erb -- line 17 uses `<% if $req_ext` while line 38 uses `<% if @req_ext`. As a result, line 17 never evaluates to true.

#### This Pull Request (PR) fixes the following issues

No issues filed currently, but verified with ewoud on Slack that the `$` syntax is just wrong for ERB.