### PR TITLE
refactor x509_request provider to be consistent with x509_cert provider

### DIFF
--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -38,21 +38,17 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
   end
 
   def create
-    cmd_args = [
+    options = [
       'req', '-new',
       '-key', resource[:private_key],
       '-config', resource[:template],
       '-out', resource[:path]
     ]
 
-    if resource[:password]
-      cmd_args.push('-passin')
-      cmd_args.push("pass:#{resource[:password]}")
-    end
+    options << ['passin', "pass:#{resource[:password]}"] if resource[:password]
+    options << ['-nodes'] unless resource[:encrypted]
 
-    cmd_args.push('-nodes') unless resource[:encrypted]
-
-    openssl(*cmd_args)
+    openssl options
   end
 
   def destroy

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
       '-out', resource[:path]
     ]
 
-    options << ['passin', "pass:#{resource[:password]}"] if resource[:password]
+    options << ['-passin', "pass:#{resource[:password]}"] if resource[:password]
     options << ['-nodes'] unless resource[:encrypted]
 
     openssl options

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -40,7 +40,7 @@ describe 'The openssl provider for the x509_request type' do
                                                          '-key', '/tmp/foo.key',
                                                          '-config', '/tmp/foo.cnf',
                                                          '-out', '/tmp/foo.csr',
-                                                         '-passin', 'pass:2x6${'
+                                                         ['-passin', 'pass:2x6${']
                                                        ])
       resource.provider.create
     end

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -22,12 +22,12 @@ describe 'The openssl provider for the x509_request type' do
     end
 
     it 'creates a certificate with the proper options' do
-      expect(provider_class).to receive(:openssl).with(
+      expect(provider_class).to receive(:openssl).with([
         'req', '-new',
         '-key', '/tmp/foo.key',
         '-config', '/tmp/foo.cnf',
         '-out', '/tmp/foo.csr'
-      )
+      ])
       resource.provider.create
     end
   end
@@ -35,13 +35,13 @@ describe 'The openssl provider for the x509_request type' do
   context 'when using password' do
     it 'creates a certificate with the proper options' do
       resource[:password] = '2x6${'
-      expect(provider_class).to receive(:openssl).with(
+      expect(provider_class).to receive(:openssl).with([
         'req', '-new',
         '-key', '/tmp/foo.key',
         '-config', '/tmp/foo.cnf',
         '-out', '/tmp/foo.csr',
         '-passin', 'pass:2x6${'
-      )
+      ])
       resource.provider.create
     end
   end

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -23,11 +23,11 @@ describe 'The openssl provider for the x509_request type' do
 
     it 'creates a certificate with the proper options' do
       expect(provider_class).to receive(:openssl).with([
-        'req', '-new',
-        '-key', '/tmp/foo.key',
-        '-config', '/tmp/foo.cnf',
-        '-out', '/tmp/foo.csr'
-      ])
+                                                         'req', '-new',
+                                                         '-key', '/tmp/foo.key',
+                                                         '-config', '/tmp/foo.cnf',
+                                                         '-out', '/tmp/foo.csr'
+                                                       ])
       resource.provider.create
     end
   end
@@ -36,12 +36,12 @@ describe 'The openssl provider for the x509_request type' do
     it 'creates a certificate with the proper options' do
       resource[:password] = '2x6${'
       expect(provider_class).to receive(:openssl).with([
-        'req', '-new',
-        '-key', '/tmp/foo.key',
-        '-config', '/tmp/foo.cnf',
-        '-out', '/tmp/foo.csr',
-        '-passin', 'pass:2x6${'
-      ])
+                                                         'req', '-new',
+                                                         '-key', '/tmp/foo.key',
+                                                         '-config', '/tmp/foo.cnf',
+                                                         '-out', '/tmp/foo.csr',
+                                                         '-passin', 'pass:2x6${'
+                                                       ])
       resource.provider.create
     end
   end


### PR DESCRIPTION
Corrects inconsistencies between the x509_cert and x509_request providers. Should help with future maintainability.