### PR TITLE
refactor x509_request to be consistent with x509_cert provider

### DIFF
--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -38,21 +38,17 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
   end
 
   def create
-    cmd_args = [
+    options = [
       'req', '-new',
       '-key', resource[:private_key],
       '-config', resource[:template],
       '-out', resource[:path]
     ]
 
-    if resource[:password]
-      cmd_args.push('-passin')
-      cmd_args.push("pass:#{resource[:password]}")
-    end
+    options << ['-passin', "pass:#{resource[:password]}"] if resource[:password]
+    options << ['-nodes'] unless resource[:encrypted]
 
-    cmd_args.push('-nodes') unless resource[:encrypted]
-
-    openssl(*cmd_args)
+    openssl options
   end
 
   def destroy

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -22,12 +22,12 @@ describe 'The openssl provider for the x509_request type' do
     end
 
     it 'creates a certificate with the proper options' do
-      expect(provider_class).to receive(:openssl).with(
-        'req', '-new',
-        '-key', '/tmp/foo.key',
-        '-config', '/tmp/foo.cnf',
-        '-out', '/tmp/foo.csr'
-      )
+      expect(provider_class).to receive(:openssl).with([
+                                                         'req', '-new',
+                                                         '-key', '/tmp/foo.key',
+                                                         '-config', '/tmp/foo.cnf',
+                                                         '-out', '/tmp/foo.csr'
+                                                       ])
       resource.provider.create
     end
   end
@@ -35,13 +35,13 @@ describe 'The openssl provider for the x509_request type' do
   context 'when using password' do
     it 'creates a certificate with the proper options' do
       resource[:password] = '2x6${'
-      expect(provider_class).to receive(:openssl).with(
-        'req', '-new',
-        '-key', '/tmp/foo.key',
-        '-config', '/tmp/foo.cnf',
-        '-out', '/tmp/foo.csr',
-        '-passin', 'pass:2x6${'
-      )
+      expect(provider_class).to receive(:openssl).with([
+                                                         'req', '-new',
+                                                         '-key', '/tmp/foo.key',
+                                                         '-config', '/tmp/foo.cnf',
+                                                         '-out', '/tmp/foo.csr',
+                                                         ['-passin', 'pass:2x6${']
+                                                       ])
       resource.provider.create
     end
   end


### PR DESCRIPTION
Failed when I renamed my branch with #154, sry for the inconvenience.
Still just makes x509_request consistent with x509_cert.