### PR TITLE
move from own regex to stdlib ip type adding ipv6 support for SANS

### DIFF
--- a/templates/cert.cnf.epp
+++ b/templates/cert.cnf.epp
@@ -72,7 +72,7 @@ emailAddress                    = <%= $email %>
     <%- %>subjectAltName    = @alt_names
     <%- %>[ alt_names ]
     <%- $subjectaltnames.each |Integer $i, String $n | { -%>
-      <%- if $n =~ /^\d+.\d+.\d+.\d+$/ { -%>
+      <%- if $n =~ Stdlib::Ip::Address::Nosubnet { -%>
         <%- %>IP.<%= $i %> = <%= $n %>
       <%- } else { -%>
         <%- %>DNS.<%= $i %> = <%= $n %>


### PR DESCRIPTION
Adds IPv6 support for SANs by moving to Stdlib::IP::Address subtype