### PR TITLE
use private key when creating x509 cert

### DIFF
--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -74,7 +74,8 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
         '-days', resource[:days],
         '-in', resource[:csr],
         '-out', resource[:path],
-        '-extfile', resource[:template]
+        '-extfile', resource[:template],
+        '-key', resource[:private_key]
       ]
       if resource[:ca]
         options << ['-CAcreateserial']

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -74,13 +74,14 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
         '-days', resource[:days],
         '-in', resource[:csr],
         '-out', resource[:path],
-        '-extfile', resource[:template],
-        '-key', resource[:private_key]
+        '-extfile', resource[:template]
       ]
       if resource[:ca]
         options << ['-CAcreateserial']
         options << ['-CA', resource[:ca]]
         options << ['-CAkey', resource[:cakey]]
+      else
+        options << ['-key', resource[:private_key]]
       end
     else
       options = [

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -193,15 +193,16 @@ define openssl::certificate::x509 (
     encrypted   => $encrypted,
   }
   ~> x509_cert { $_crt:
-    ensure   => $ensure,
-    template => $_cnf,
-    csr      => $_csr,
-    days     => $days,
-    password => $password,
-    req_ext  => $req_ext,
-    force    => $force,
-    ca       => $ca,
-    cakey    => $cakey,
+    ensure      => $ensure,
+    template    => $_cnf,
+    csr         => $_csr,
+    private_key => $_key,
+    days        => $days,
+    password    => $password,
+    req_ext     => $req_ext,
+    force       => $force,
+    ca          => $ca,
+    cakey       => $cakey,
   }
 
   # Set owner of all files


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Fixes usage of `openssl::certificate::x509` where the private key was not passed into OpenSSL correctly. This could collide with L83 in `lib/puppet/provider/x509_cert/openssl.rb` but I don't have time to test this use case.