### PR TITLE
Make x509 altnames and extkeyusage optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -408,16 +408,16 @@ certificate CommonName
 
 ##### <a name="-openssl--certificate--x509--altnames"></a>`altnames`
 
-Data type: `Array`
+Data type: `Optional[Array[String[1]]]`
 
 certificate subjectAltName.
 Can be an array or a single string.
 
-Default value: `[]`
+Default value: `undef`
 
 ##### <a name="-openssl--certificate--x509--extkeyusage"></a>`extkeyusage`
 
-Data type: `Array`
+Data type: `Optional[Array[String[1]]]`
 
 certificate extended key usage
 Value           | Meaning
@@ -434,7 +434,7 @@ msCodeCom       | Microsoft Commercial Code Signing (authenticode)
 msCTLSign       | Microsoft Trust List Signing
 msEFS           | Microsoft Encrypted File System
 
-Default value: `[]`
+Default value: `undef`
 
 ##### <a name="-openssl--certificate--x509--organization"></a>`organization`
 

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -123,8 +123,8 @@ define openssl::certificate::x509 (
   Optional[String]                   $state = undef,
   Optional[String]                   $locality = undef,
   Optional[String]                   $unit = undef,
-  Array                              $altnames = [],
-  Array                              $extkeyusage = [],
+  Optional[Array[String[1]]]         $altnames = undef,
+  Optional[Array[String[1]]]         $extkeyusage = undef,
   Optional[String]                   $email = undef,
   Integer                            $days = 365,
   Stdlib::Absolutepath               $base_dir = '/etc/ssl/certs',
@@ -159,7 +159,7 @@ define openssl::certificate::x509 (
   $_csr = pick($csr, "${_csr_dir}/${name}.csr")
   $_key = pick($key, "${_key_dir}/${name}.key")
 
-  if !empty($altnames+$extkeyusage) {
+  if $altnames or $extkeyusage {
     $req_ext = true
   } else {
     $req_ext = false

--- a/spec/defines/openssl_certificate_x509_spec.rb
+++ b/spec/defines/openssl_certificate_x509_spec.rb
@@ -393,6 +393,8 @@ describe 'openssl::certificate::x509' do
         %r{organizationName\s+=\s+bar}
       ).with_content(
         %r{commonName\s+=\s+baz}
+      ).without_content(
+        %r{v3_req}
       )
     }
 


### PR DESCRIPTION
The defaults of empty arrays are generating invalid openssl configs

Example of what's generated:

```
[ v3_req ]
extendedKeyUsage  =
subjectAltName    = @alt_names
```

This throws all sorts of errors:

```
[root@rocky-8 /]# /opt/puppetlabs/puppet/bin/openssl req -new -key /etc/xdmod/simplesamlphp/cert/xdmod.key -config /etc/xdmod/simplesamlphp/cert/xdmod.cnf -out /etc/xdmod/simplesamlphp/cert/xdmod.csr
Error Loading request extension section v3_req
46912522284800:error:2206D06C:X509 V3 routines:X509V3_parse_list:invalid null name:crypto/x509v3/v3_utl.c:386:
46912522284800:error:22097069:X509 V3 routines:do_ext_nconf:invalid extension string:crypto/x509v3/v3_conf.c:93:name=extendedKeyUsage,section=
46912522284800:error:22098080:X509 V3 routines:X509V3_EXT_nconf:error in extension:crypto/x509v3/v3_conf.c:47:name=extendedKeyUsage, value=
```