### PR TITLE
Fix handling of request extensions in x509_cert type and provider

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1311,7 +1311,7 @@ discover the appropriate provider for your platform.
 
 ##### <a name="-x509_cert--req_ext"></a>`req_ext`
 
-Valid values: `true`, `false`
+Valid values: `true`, `false`, `yes`, `no`
 
 Whether adding v3 SAN from config
 

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -73,13 +73,21 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
         '-req',
         '-days', resource[:days],
         '-in', resource[:csr],
-        '-out', resource[:path],
-        '-extfile', resource[:template]
+        '-out', resource[:path]
       ]
       if resource[:ca]
+        options << ['-extfile', resource[:template]]
         options << ['-CAcreateserial']
         options << ['-CA', resource[:ca]]
         options << ['-CAkey', resource[:cakey]]
+      else
+        options << ['-signkey', resource[:private_key]]
+        if resource[:req_ext]
+          options << [
+            '-extensions', 'v3_req',
+            '-extfile', resource[:template]
+          ]
+        end
       end
     else
       options = [

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -42,9 +42,8 @@ Puppet::Type.newtype(:x509_cert) do
     desc 'The optional password for the private key'
   end
 
-  newparam(:req_ext, boolean: true) do
+  newparam(:req_ext, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc 'Whether adding v3 SAN from config'
-    newvalues(:true, :false)
     defaultto false
   end
 

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -69,7 +69,7 @@ describe 'The openssl provider for the x509_cert type' do
                                                          '-days', 3650,
                                                          '-in', '/tmp/foo.csr',
                                                          '-out', '/tmp/foo.crt',
-                                                         '-extfile', '/tmp/foo.cnf',
+                                                         ['-extfile', '/tmp/foo.cnf'],
                                                          ['-CAcreateserial'],
                                                          ['-CA', '/tmp/foo-ca.crt'],
                                                          ['-CAkey', '/tmp/foo-ca.key'],

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -56,7 +56,7 @@ describe Puppet::Type.type(:x509_cert) do
 
   it 'accepts a valid req_ext parameter' do
     resource[:req_ext] = true
-    expect(resource[:req_ext]).to eq(:true)
+    expect(resource[:req_ext]).to be(true)
   end
 
   it 'does not accept a bad req_ext parameter' do


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes an issue handling request extensions in the x509_cert provider when issueing self-signed certificates.

#### This Pull Request (PR) fixes the following issues

Along with #179, this Fixes #178