### PR TITLE
Use private_key parameter when creating certificate

### DIFF
--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -184,6 +184,7 @@ define openssl::certificate::x509 (
   ~> x509_cert { $crt:
     ensure         => $ensure,
     template       => $cnf,
+    private_key    => $key,
     csr            => $csr,
     days           => $days,
     password       => $password,


### PR DESCRIPTION
#### Pull Request (PR) description
Use private key created before, not the default value.

#### This Pull Request (PR) fixes the following issues
Fixes #185
