### PR TITLE
Do not reveal sensitive Data

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -531,7 +531,7 @@ Default value: `'0600'`
 
 ##### <a name="-openssl--certificate--x509--password"></a>`password`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 private key password. undef means no passphrase
 will be used to encrypt private key.
@@ -953,7 +953,7 @@ Default value: `$title`
 
 ##### <a name="-openssl--export--pem_cert--in_pass"></a>`in_pass`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 PFX password
 
@@ -997,7 +997,7 @@ Default value: `present`
 
 ##### <a name="-openssl--export--pem_key--in_pass"></a>`in_pass`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 PFX container password
 
@@ -1005,7 +1005,7 @@ Default value: `undef`
 
 ##### <a name="-openssl--export--pem_key--out_pass"></a>`out_pass`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 PEM key password
 
@@ -1055,7 +1055,7 @@ Default value: `present`
 
 ##### <a name="-openssl--export--pkcs12--in_pass"></a>`in_pass`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 Private key password
 
@@ -1063,7 +1063,7 @@ Default value: `undef`
 
 ##### <a name="-openssl--export--pkcs12--out_pass"></a>`out_pass`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Sensitive[String], String]]`
 
 PKCS12 password
 

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -26,7 +26,11 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
   def self.to_pem(resource, key)
     if resource[:password]
       cipher = OpenSSL::Cipher.new('des3')
-      key.to_pem(cipher, resource[:password])
+      if resource[:password].respond_to?(:unwrap)
+        Puppet::Pops::Types::PSensitiveType::Sensitive.new(key.to_pem(cipher, resource[:password].unwrap))
+      else
+        key.to_pem(cipher, resource[:password])
+      end
     else
       key.to_pem
     end

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -10,11 +10,23 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
     file = File.read(resource[:private_key])
     case resource[:authentication]
     when :dsa
-      OpenSSL::PKey::DSA.new(file, resource[:password])
+      if resource[:password].respond_to?(:unwrap)
+        Puppet::Pops::Types::PSensitiveType::Sensitive.new(OpenSSL::PKey::DSA.new(file, resource[:password].unwrap))
+      else
+        OpenSSL::PKey::DSA.new(file, resource[:password])
+      end
     when :rsa
-      OpenSSL::PKey::RSA.new(file, resource[:password])
+      if resource[:password].respond_to?(:unwrap)
+        Puppet::Pops::Types::PSensitiveType::Sensitive.new(OpenSSL::PKey::RSA.new(file, resource[:password].unwrap))
+      else
+        OpenSSL::PKey::RSA.new(file, resource[:password])
+      end
     when :ec
-      OpenSSL::PKey::EC.new(file, resource[:password])
+      if resource[:password].respond_to?(:unwrap)
+        Puppet::Pops::Types::PSensitiveType::Sensitive.new(OpenSSL::PKey::EC.new(file, resource[:password].unwrap))
+      else
+        OpenSSL::PKey::EC.new(file, resource[:password])
+      end
     else
       raise Puppet::Error,
             "Unknown authentication type '#{resource[:authentication]}'"
@@ -99,7 +111,11 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
         '-out', resource[:path]
       ]
     end
-    options << ['-passin', "pass:#{resource[:password]}"] if resource[:password]
+    if resource[:password].respond_to?(:unwrap)
+      options << ['-passin', "pass:#{resource[:password].unwrap}"]
+    elsif resource[:password]
+      options << ['-passin', "pass:#{resource[:password]}"]
+    end
     options << ['-extensions', 'v3_req'] if resource[:req_ext] != :false
     openssl options
   end

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -142,7 +142,7 @@ define openssl::certificate::x509 (
   Variant[String, Integer]       $key_owner = $owner,
   Variant[String, Integer]       $key_group = $group,
   Stdlib::Filemode               $key_mode = '0600',
-  Optional[String]               $password = undef,
+  Optional[Variant[Sensitive[String], String]] $password = undef,
   Boolean                        $force = true,
   Boolean                        $encrypted = true,
   Optional[Stdlib::Absolutepath] $ca = undef,


### PR DESCRIPTION
Allow Passwords to be of Puppet-Datatype `Sensitive`.  
Return `Sensitive`, if Passwords were provided as `Sensitive`.
