### PR TITLE
Use native OpenSSL methods to automatically determine the PKey

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -10,17 +10,17 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
   end
 
   def self.generate_key(resource)
+    options = {}
     case resource[:authentication]
     when :dsa
-      OpenSSL::PKey::DSA.new(resource[:size])
+      options[:dsa_paramgen_bits] = resource[:size] if resource[:size]
     when :rsa
-      OpenSSL::PKey::RSA.new(resource[:size])
+      options[:rsa_keygen_bits] = resource[:size] if resource[:size]
     when :ec
-      OpenSSL::PKey::EC.new(resource[:curve]).generate_key
-    else
-      raise Puppet::Error,
-            "Unknown authentication type '#{resource[:authentication]}'"
+      options[:ec_paramgen_curve] = resource[:curve] if resource[:curve]
     end
+
+    OpenSSL::PKey.generate_key(resource[:authentication].to_s.upcase, options)
   end
 
   def self.to_pem(resource, key)

--- a/spec/unit/puppet/provider/cert_file/posix_spec.rb
+++ b/spec/unit/puppet/provider/cert_file/posix_spec.rb
@@ -7,7 +7,7 @@ require 'webmock/rspec'
 require 'openssl'
 describe 'The POSIX provider for type cert_file' do
   before do
-    test_keys = OpenSSL::PKey::RSA.new(2049)
+    test_keys = OpenSSL::PKey.generate_key('RSA')
     test_cert = OpenSSL::X509::Certificate.new
     test_cert.version = 2
     test_cert.serial = 1


### PR DESCRIPTION
This came up in https://github.com/voxpupuli/puppet-openssl/pull/187#discussion_r1609710197 but it's probably also needed for https://github.com/voxpupuli/puppet-openssl/pull/167.

One thing to note is that we may have more problems in the future. For example, on my Fedora I don't appear to be allowed to generate any DSA key in the default SSL policy. I imagine future enterprise distros will follow this exampe.