### PR TITLE
Use OpenSSL::PKey.read to read private keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1309,7 +1309,6 @@ Default value: `present`
 
 The following parameters are available in the `x509_cert` type.
 
-* [`authentication`](#-x509_cert--authentication)
 * [`ca`](#-x509_cert--ca)
 * [`cakey`](#-x509_cert--cakey)
 * [`csr`](#-x509_cert--csr)
@@ -1321,14 +1320,6 @@ The following parameters are available in the `x509_cert` type.
 * [`provider`](#-x509_cert--provider)
 * [`req_ext`](#-x509_cert--req_ext)
 * [`template`](#-x509_cert--template)
-
-##### <a name="-x509_cert--authentication"></a>`authentication`
-
-Valid values: `rsa`, `dsa`, `ec`
-
-The authentication algorithm: 'rsa', 'dsa or ec'
-
-Default value: `rsa`
 
 ##### <a name="-x509_cert--ca"></a>`ca`
 
@@ -1407,7 +1398,6 @@ Default value: `present`
 
 The following parameters are available in the `x509_request` type.
 
-* [`authentication`](#-x509_request--authentication)
 * [`encrypted`](#-x509_request--encrypted)
 * [`force`](#-x509_request--force)
 * [`password`](#-x509_request--password)
@@ -1415,14 +1405,6 @@ The following parameters are available in the `x509_request` type.
 * [`private_key`](#-x509_request--private_key)
 * [`provider`](#-x509_request--provider)
 * [`template`](#-x509_request--template)
-
-##### <a name="-x509_request--authentication"></a>`authentication`
-
-Valid values: `rsa`, `dsa`, `ec`
-
-The authentication algorithm: 'rsa', 'dsa' or ec
-
-Default value: `rsa`
 
 ##### <a name="-x509_request--encrypted"></a>`encrypted`
 

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -8,17 +8,7 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
 
   def self.private_key(resource)
     file = File.read(resource[:private_key])
-    case resource[:authentication]
-    when :dsa
-      OpenSSL::PKey::DSA.new(file, resource[:password])
-    when :rsa
-      OpenSSL::PKey::RSA.new(file, resource[:password])
-    when :ec
-      OpenSSL::PKey::EC.new(file, resource[:password])
-    else
-      raise Puppet::Error,
-            "Unknown authentication type '#{resource[:authentication]}'"
-    end
+    OpenSSL::PKey.read(file, resource[:password])
   end
 
   def self.check_private_key(resource)

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -8,17 +8,7 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
 
   def self.private_key(resource)
     file = File.read(resource[:private_key])
-    case resource[:authentication]
-    when :dsa
-      OpenSSL::PKey::DSA.new(file, resource[:password])
-    when :rsa
-      OpenSSL::PKey::RSA.new(file, resource[:password])
-    when :ec
-      OpenSSL::PKey::EC.new(file, resource[:password])
-    else
-      raise Puppet::Error,
-            "Unknown authentication type '#{resource[:authentication]}'"
-    end
+    OpenSSL::PKey.read(file, resource[:password])
   end
 
   def self.check_private_key(resource)

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -60,12 +60,6 @@ Puppet::Type.newtype(:x509_cert) do
     end
   end
 
-  newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa', 'dsa or ec'"
-    newvalues :rsa, :dsa, :ec
-    defaultto :rsa
-  end
-
   newparam(:csr) do
     desc 'The optional certificate signing request path'
   end

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -48,12 +48,6 @@ Puppet::Type.newtype(:x509_request) do
     end
   end
 
-  newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa', 'dsa' or ec"
-    newvalues :rsa, :dsa, :ec
-    defaultto :rsa
-  end
-
   newparam(:encrypted, boolean: true) do
     desc 'Whether to generate the key unencrypted. This is needed by some applications like OpenLDAP'
     newvalues(:true, :false)

--- a/spec/unit/puppet/provider/cert_file/posix_spec.rb
+++ b/spec/unit/puppet/provider/cert_file/posix_spec.rb
@@ -25,11 +25,13 @@ describe 'The POSIX provider for type cert_file' do
   end
 
   let(:path) { '/tmp/test.pem' }
+  let(:pathname) { instance_double(Pathname) }
   let(:source) { 'http://example.org/cert.der' }
   let(:resource) { Puppet::Type::Cert_file.new(path: path, source: source) }
 
   it 'exists? returns false on arbitraty path' do
-    allow_any_instance_of(Pathname).to receive(:exist?).and_return(false) # rubocop:disable RSpec/AnyInstance
+    allow(Pathname).to receive(:new).with(path).and_return(pathname)
+    allow(pathname).to receive(:exist?).and_return(false)
     expect(resource.provider.exists?).to be(false)
   end
 

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -25,7 +25,7 @@ describe 'The openssl provider for the ssl_pkey type' do
   context 'when creating a key with defaults' do
     it 'creates an rsa key' do
       allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-      allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+      expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
 
@@ -33,7 +33,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given size' do
         resource[:size] = 1024
         allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -43,7 +43,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -53,7 +53,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     it 'creates a dsa key' do
       resource[:authentication] = :rsa
       allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-      allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+      expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
 
@@ -62,7 +62,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :rsa
         resource[:size] = 1024
         allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -73,7 +73,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -83,7 +83,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     it 'creates a dsa key' do
       resource[:authentication] = :dsa
       allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
-      allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+      expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
 
@@ -92,7 +92,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :dsa
         resource[:size] = 1024
         allow(OpenSSL::PKey::DSA).to receive(:new).with(1024).and_return(key)
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -103,7 +103,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -115,7 +115,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     it 'creates an ec key' do
       resource[:authentication] = :ec
       allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
-      allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+      expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
 
@@ -124,7 +124,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :ec
         resource[:curve] = 'prime239v1'
         allow(OpenSSL::PKey::EC).to receive(:new).with('prime239v1').and_return(key)
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end
@@ -135,7 +135,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
-        allow(File).to receive(:open).with('/tmp/foo.key', 'w')
+        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
     end

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -8,20 +8,25 @@ require 'puppet/type/x509_cert'
 provider_class = Puppet::Type.type(:x509_cert).provider(:openssl)
 describe 'The openssl provider for the x509_cert type' do
   let(:path) { '/tmp/foo.crt' }
+  let(:pathname) { Pathname.new(path) }
   let(:resource) { Puppet::Type::X509_cert.new(path: path) }
   let(:cert) { OpenSSL::X509::Certificate.new }
 
   context 'when not forcing key' do
     it 'exists? should return true if certificate exists and is synced' do
       allow(File).to receive(:read)
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       c = OpenSSL::X509::Certificate.new # Fake certificate for mocking
       allow(OpenSSL::X509::Certificate).to receive(:new).and_return(c)
       expect(resource.provider.exists?).to be(true)
     end
 
     it 'exists? should return false if certificate does not exist' do
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false) # rubocop:disable RSpec/AnyInstance
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end
 
@@ -83,7 +88,8 @@ describe 'The openssl provider for the x509_cert type' do
     it 'exists? should return true if certificate exists and is synced' do
       resource[:force] = true
       allow(File).to receive(:read)
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
       allow(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:check_private_key).and_return(true)
@@ -93,7 +99,8 @@ describe 'The openssl provider for the x509_cert type' do
     it 'exists? should return false if certificate exists and is not synced' do
       resource[:force] = true
       allow(File).to receive(:read)
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
       allow(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:check_private_key).and_return(false)
@@ -102,13 +109,16 @@ describe 'The openssl provider for the x509_cert type' do
 
     it 'exists? should return false if certificate does not exist' do
       resource[:force] = true
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end
   end
 
   it 'deletes files' do
-    allow_any_instance_of(Pathname).to receive(:delete) # rubocop:disable RSpec/AnyInstance
+    allow(Pathname).to receive(:new).and_call_original
+    allow(Pathname).to receive(:new).with(path).and_return(pathname)
+    expect(pathname).to receive(:delete)
     resource.provider.destroy
   end
 end

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -92,7 +92,7 @@ describe 'The openssl provider for the x509_cert type' do
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
       expect(OpenSSL::X509::Certificate).to receive(:new).with('cert').twice.and_return(cert)
-      expect(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::PKey).to receive(:read).with('pkey', nil)
       expect(cert).to receive(:check_private_key).and_return(true)
       expect(resource.provider.exists?).to be(true)
     end
@@ -104,7 +104,7 @@ describe 'The openssl provider for the x509_cert type' do
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
       expect(OpenSSL::X509::Certificate).to receive(:new).with('cert').and_return(cert)
-      expect(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::PKey).to receive(:read).with('pkey', nil)
       expect(cert).to receive(:check_private_key).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -87,22 +87,24 @@ describe 'The openssl provider for the x509_cert type' do
   context 'when forcing key' do
     it 'exists? should return true if certificate exists and is synced' do
       resource[:force] = true
-      allow(File).to receive(:read)
+      expect(File).to receive(:read).with('/tmp/foo.crt').twice.and_return('cert')
+      expect(File).to receive(:read).with('/tmp/foo.key').and_return('pkey')
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
-      allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
-      allow(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::X509::Certificate).to receive(:new).with('cert').twice.and_return(cert)
+      expect(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:check_private_key).and_return(true)
       expect(resource.provider.exists?).to be(true)
     end
 
     it 'exists? should return false if certificate exists and is not synced' do
       resource[:force] = true
-      allow(File).to receive(:read)
+      expect(File).to receive(:read).with('/tmp/foo.crt').and_return('cert')
+      expect(File).to receive(:read).with('/tmp/foo.key').and_return('pkey')
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
-      allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
-      allow(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::X509::Certificate).to receive(:new).with('cert').and_return(cert)
+      expect(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:check_private_key).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -58,7 +58,7 @@ describe 'The openssl provider for the x509_request type' do
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Request).to receive(:new).and_return(cert)
-      allow(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::PKey).to receive(:read)
       expect(cert).to receive(:verify).and_return(true)
       expect(resource.provider.exists?).to be(true)
     end
@@ -69,7 +69,7 @@ describe 'The openssl provider for the x509_request type' do
       expect(Pathname).to receive(:new).with(path).and_return(pathname)
       expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Request).to receive(:new).and_return(cert)
-      allow(OpenSSL::PKey::RSA).to receive(:new)
+      expect(OpenSSL::PKey).to receive(:read)
       expect(cert).to receive(:verify).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end

--- a/spec/unit/puppet/provider/x509_request/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_request/openssl_spec.rb
@@ -7,17 +7,22 @@ require 'puppet/type/x509_request'
 provider_class = Puppet::Type.type(:x509_request).provider(:openssl)
 describe 'The openssl provider for the x509_request type' do
   let(:path) { '/tmp/foo.csr' }
+  let(:pathname) { Pathname.new(path) }
   let(:resource) { Puppet::Type::X509_request.new(path: path) }
   let(:cert) { OpenSSL::X509::Request.new }
 
   context 'when not forcing key' do
     it 'exists? should return true if csr exists' do
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       expect(resource.provider.exists?).to be(true)
     end
 
     it 'exists? should return false if csr exists' do
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false) # rubocop:disable RSpec/AnyInstance
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end
 
@@ -50,7 +55,8 @@ describe 'The openssl provider for the x509_request type' do
     it 'exists? should return true if certificate exists and is synced' do
       resource[:force] = true
       allow(File).to receive(:read)
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Request).to receive(:new).and_return(cert)
       allow(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:verify).and_return(true)
@@ -60,7 +66,8 @@ describe 'The openssl provider for the x509_request type' do
     it 'exists? should return false if certificate exists and is not synced' do
       resource[:force] = true
       allow(File).to receive(:read)
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(true)
       allow(OpenSSL::X509::Request).to receive(:new).and_return(cert)
       allow(OpenSSL::PKey::RSA).to receive(:new)
       expect(cert).to receive(:verify).and_return(false)
@@ -69,13 +76,16 @@ describe 'The openssl provider for the x509_request type' do
 
     it 'exists? should return false if certificate does not exist' do
       resource[:force] = true
-      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false) # rubocop:disable RSpec/AnyInstance
+      expect(Pathname).to receive(:new).with(path).and_return(pathname)
+      expect(pathname).to receive(:exist?).and_return(false)
       expect(resource.provider.exists?).to be(false)
     end
   end
 
   it 'deletes files' do
-    allow_any_instance_of(Pathname).to receive(:delete) # rubocop:disable RSpec/AnyInstance
+    allow(Pathname).to receive(:new).and_call_original
+    allow(Pathname).to receive(:new).with(path).and_return(pathname)
+    expect(pathname).to receive(:delete)
     resource.provider.destroy
   end
 end

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -65,21 +65,6 @@ describe Puppet::Type.type(:x509_cert) do
     end.to raise_error(Puppet::Error, %r{Invalid value :foo})
   end
 
-  it 'accepts a valid authentication' do
-    resource[:authentication] = :rsa
-    expect(resource[:authentication]).to eq(:rsa)
-    resource[:authentication] = :dsa
-    expect(resource[:authentication]).to eq(:dsa)
-    resource[:authentication] = :ec
-    expect(resource[:authentication]).to eq(:ec)
-  end
-
-  it 'does not accept an invalid authentication' do
-    expect do
-      resource[:authentication] = :foo
-    end.to raise_error(Puppet::Error, %r{Invalid value :foo})
-  end
-
   it 'accepts a valid csr parameter' do
     resource[:csr] = '/tmp/foo.csr'
     expect(resource[:csr]).to eq('/tmp/foo.csr')

--- a/spec/unit/puppet/type/x509_request_spec.rb
+++ b/spec/unit/puppet/type/x509_request_spec.rb
@@ -53,19 +53,4 @@ describe Puppet::Type.type(:x509_request) do
       resource[:force] = :foo
     end.to raise_error(Puppet::Error, %r{Invalid value :foo})
   end
-
-  it 'accepts a valid authentication' do
-    resource[:authentication] = :rsa
-    expect(resource[:authentication]).to eq(:rsa)
-    resource[:authentication] = :dsa
-    expect(resource[:authentication]).to eq(:dsa)
-    resource[:authentication] = :ec
-    expect(resource[:authentication]).to eq(:ec)
-  end
-
-  it 'does not accept an invalid authentication' do
-    expect do
-      resource[:authentication] = :foo
-    end.to raise_error(Puppet::Error, %r{Invalid value :foo})
-  end
 end


### PR DESCRIPTION
This utilizes a method where OpenSSL itself determines the encryption type rather than a static parameter. This is more flexible because it requires fewer parameters to be specified.

Prior to that it does several cleanups to the tests.