### PR TITLE
Add missing require so that generate types works.

### DIFF
--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'puppet/parameter/boolean'
 require 'pathname'
 Puppet::Type.newtype(:x509_cert) do
   desc 'An x509 certificate'


### PR DESCRIPTION
#### Pull Request (PR) description

Generate types fails for x509_cert due to missing type require.

#### This Pull Request (PR) fixes the following issues

Fixes #197 
