### PR TITLE
export/{pem_cert,pem_key,pkcs12}: `passin`, `passout`: use `shellquote()` instead of single quotation marks

### DIFF
--- a/manifests/export/pem_cert.pp
+++ b/manifests/export/pem_cert.pp
@@ -42,7 +42,7 @@ define openssl::export::pem_cert (
 
   $passin_opt = $in_pass ? {
     undef   => '',
-    default => "-nokeys -passin pass:'${in_pass}'",
+    default => "-nokeys -passin pass:${shellquote($in_pass)}",
   }
 
   if $ensure == 'present' {

--- a/manifests/export/pem_key.pp
+++ b/manifests/export/pem_key.pp
@@ -21,12 +21,12 @@ define openssl::export::pem_key (
   if $ensure == 'present' {
     $passin_opt = $in_pass ? {
       undef   => '',
-      default => "-passin pass:'${in_pass}'",
+      default => "-passin pass:${in_pass}",
     }
 
     $passout_opt = $out_pass ? {
       undef   => '-nodes',
-      default => "-passout pass:'${out_pass}'",
+      default => "-passout pass:${out_pass}",
     }
 
     $cmd = [

--- a/manifests/export/pem_key.pp
+++ b/manifests/export/pem_key.pp
@@ -21,12 +21,12 @@ define openssl::export::pem_key (
   if $ensure == 'present' {
     $passin_opt = $in_pass ? {
       undef   => '',
-      default => "-passin pass:${in_pass}",
+      default => "-passin pass:${shellquote($in_pass)}",
     }
 
     $passout_opt = $out_pass ? {
       undef   => '-nodes',
-      default => "-passout pass:${out_pass}",
+      default => "-passout pass:${shellquote($out_pass)}",
     }
 
     $cmd = [

--- a/manifests/export/pkcs12.pp
+++ b/manifests/export/pkcs12.pp
@@ -27,12 +27,12 @@ define openssl::export::pkcs12 (
   if $ensure == 'present' {
     $pass_opt = $in_pass ? {
       undef   => '',
-      default => "-passin pass:${in_pass}",
+      default => "-passin pass:${shellquote($in_pass)}",
     }
 
     $passout_opt = $out_pass ? {
       undef   => '',
-      default => "-passout pass:${out_pass}",
+      default => "-passout pass:${shellquote($out_pass)}",
     }
 
     $chain_opt = $chaincert ? {


### PR DESCRIPTION
#### Pull Request (PR) description
Remove unnecessary single quotes for passin and passout parameter.
Also fixes a bug, where the quotation is interpreted as a part of the password
