### PR TITLE
Drop EoL CentOS 6,7,8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -41,7 +42,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -38,9 +38,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8",
         "9"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -31,8 +31,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
-        "7",
         "8",
         "9"
       ]


### PR DESCRIPTION
also contains https://github.com/voxpupuli/puppet-openssl/pull/210 https://github.com/voxpupuli/puppet-openssl/pull/211