### PR TITLE
acceptance tests: use 1024 bit keys

### DIFF
--- a/examples/x509_cert.pp
+++ b/examples/x509_cert.pp
@@ -6,5 +6,6 @@ openssl::certificate::x509 { 'foo.example.com':
   base_dir     => '/tmp',
   owner        => 'nobody',
   password     => 'mahje1Qu',
+  # This is just to speed up CI - use 2048 or more in production
   key_size     => 1024,
 }

--- a/examples/x509_cert.pp
+++ b/examples/x509_cert.pp
@@ -6,4 +6,5 @@ openssl::certificate::x509 { 'foo.example.com':
   base_dir     => '/tmp',
   owner        => 'nobody',
   password     => 'mahje1Qu',
+  key_size     => 1024,
 }

--- a/spec/acceptance/x509_cert_spec.rb
+++ b/spec/acceptance/x509_cert_spec.rb
@@ -15,7 +15,7 @@ describe 'x509_cert example' do
       it { is_expected.to be_certificate }
       it { is_expected.to be_valid }
       its(:subject) { is_expected.to match_without_whitespace(%r{C = CH, O = Example.com, CN = foo.example.com}) }
-      its(:keylength) { is_expected.to eq 3072 }
+      its(:keylength) { is_expected.to eq 1024 }
     end
 
     it { expect(file('/tmp/foo.example.com.key')).to be_file.and(have_attributes(owner: 'nobody', mode: '600')) }


### PR DESCRIPTION
This is way faster to generate compared to the default 3072. Otherwise our CI runs for ages.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
