### PR TITLE
Use OpenSSL::PKey.generate_pkey instead of OpenSSL::PKey::Algo

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -9,14 +9,16 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
     resource[:path].dirname
   end
 
+  # @see man openssl genpkey
   def self.generate_key(resource)
     case resource[:authentication]
     when :dsa
-      OpenSSL::PKey::DSA.new(resource[:size])
+      params = OpenSSL::PKey.generate_parameters('DSA', 'dsa_paramgen_bits' => resource[:size])
+      OpenSSL::PKey.generate_key(params)
     when :rsa
-      OpenSSL::PKey::RSA.new(resource[:size])
+      OpenSSL::PKey.generate_key('RSA', 'rsa_keygen_bits' => resource[:size])
     when :ec
-      OpenSSL::PKey::EC.new(resource[:curve]).generate_key
+      OpenSSL::PKey.generate_key('EC', 'ec_paramgen_curve' => resource[:curve])
     else
       raise Puppet::Error,
             "Unknown authentication type '#{resource[:authentication]}'"

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -8,7 +8,6 @@ describe 'The openssl provider for the ssl_pkey type' do
   let(:path) { '/tmp/foo.key' }
   let(:pathname) { Pathname.new(path) }
   let(:resource) { Puppet::Type::Ssl_pkey.new(path: path) }
-  let(:key) { OpenSSL::PKey::RSA.new }
 
   it 'exists? should return true if key exists' do
     expect(Pathname).to receive(:new).twice.with(path).and_return(pathname)
@@ -24,7 +23,7 @@ describe 'The openssl provider for the ssl_pkey type' do
 
   context 'when creating a key with defaults' do
     it 'creates an rsa key' do
-      allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+      expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 2048).and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -32,7 +31,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting size' do
       it 'creates with given size' do
         resource[:size] = 1024
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 1024).and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -41,7 +40,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting password' do
       it 'creates with given password' do
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 2048).and_call_original
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
@@ -50,9 +49,9 @@ describe 'The openssl provider for the ssl_pkey type' do
   end
 
   context 'when setting authentication to rsa' do
-    it 'creates a dsa key' do
+    it 'creates an rsa key' do
       resource[:authentication] = :rsa
-      allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+      expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 2048).and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -61,7 +60,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given size' do
         resource[:authentication] = :rsa
         resource[:size] = 1024
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 1024).and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -71,7 +70,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:authentication] = :rsa
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_key).with('RSA', 'rsa_keygen_bits' => 2048).and_call_original
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
@@ -82,7 +81,8 @@ describe 'The openssl provider for the ssl_pkey type' do
   context 'when setting authentication to dsa' do
     it 'creates a dsa key' do
       resource[:authentication] = :dsa
-      allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
+      expect(OpenSSL::PKey).to receive(:generate_parameters).with('DSA', 'dsa_paramgen_bits' => 2048).and_call_original
+      expect(OpenSSL::PKey).to receive(:generate_key).with(kind_of(OpenSSL::PKey::DSA)).and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -91,7 +91,8 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given size' do
         resource[:authentication] = :dsa
         resource[:size] = 1024
-        allow(OpenSSL::PKey::DSA).to receive(:new).with(1024).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_parameters).with('DSA', 'dsa_paramgen_bits' => 1024).and_call_original
+        expect(OpenSSL::PKey).to receive(:generate_key).with(kind_of(OpenSSL::PKey::DSA)).and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -101,7 +102,8 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:authentication] = :dsa
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_parameters).with('DSA', 'dsa_paramgen_bits' => 2048).and_call_original
+        expect(OpenSSL::PKey).to receive(:generate_key).with(kind_of(OpenSSL::PKey::DSA)).and_call_original
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
@@ -110,11 +112,9 @@ describe 'The openssl provider for the ssl_pkey type' do
   end
 
   context 'when setting authentication to ec' do
-    key = OpenSSL::PKey::EC.new('secp384r1').generate_key # For mocking
-
     it 'creates an ec key' do
       resource[:authentication] = :ec
-      allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
+      expect(OpenSSL::PKey).to receive(:generate_key).with('EC', 'ec_paramgen_curve' => 'secp384r1').and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -122,8 +122,9 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting curve' do
       it 'creates with given curve' do
         resource[:authentication] = :ec
-        resource[:curve] = 'prime239v1'
-        allow(OpenSSL::PKey::EC).to receive(:new).with('prime239v1').and_return(key)
+        # See: openssl ecparam -list_curves
+        resource[:curve] = 'prime256v1'
+        expect(OpenSSL::PKey).to receive(:generate_key).with('EC', 'ec_paramgen_curve' => 'prime256v1').and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -133,7 +134,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:authentication] = :ec
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
+        expect(OpenSSL::PKey).to receive(:generate_key).with('EC', 'ec_paramgen_curve' => 'secp384r1').and_call_original
         allow(OpenSSL::Cipher).to receive(:new).with('des3')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create


### PR DESCRIPTION
This is the recommended way to generate private keys.

I vaguely recall that this requires OpenSSL 3.0 but acceptance tests should show it if I break things.