### PR TITLE
password encryption: switch from des3->aes-256-cbc

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
 
   def self.to_pem(resource, key)
     if resource[:password]
-      cipher = OpenSSL::Cipher.new('des3')
+      cipher = OpenSSL::Cipher.new('aes-256-cbc')
       key.to_pem(cipher, resource[:password])
     else
       key.to_pem

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -42,7 +42,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
+        expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -72,7 +72,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :rsa
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
+        expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -102,7 +102,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :dsa
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
+        expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -134,7 +134,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :ec
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
+        expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -42,7 +42,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('des3')
+        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -72,7 +72,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :rsa
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('des3')
+        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -102,7 +102,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :dsa
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('des3')
+        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -134,7 +134,7 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :ec
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
-        allow(OpenSSL::Cipher).to receive(:new).with('des3')
+        allow(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end


### PR DESCRIPTION
This updates the algorithm for password encryption in certificates from the outdated des3 to aes-256-cbc.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
