### PR TITLE
Drop DSA key support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1265,9 +1265,9 @@ The following parameters are available in the `ssl_pkey` type.
 
 ##### <a name="-ssl_pkey--authentication"></a>`authentication`
 
-Valid values: `rsa`, `dsa`, `ec`
+Valid values: `rsa`, `ec`
 
-The authentication algorithm: 'rsa', 'dsa or ec'
+The authentication algorithm
 
 Default value: `rsa`
 
@@ -1294,7 +1294,7 @@ discover the appropriate provider for your platform.
 
 Valid values: `%r{\d+}`
 
-The key size
+The key size for RSA keys
 
 Default value: `2048`
 

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -11,8 +11,6 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
 
   def self.generate_key(resource)
     case resource[:authentication]
-    when :dsa
-      OpenSSL::PKey::DSA.new(resource[:size])
     when :rsa
       OpenSSL::PKey::RSA.new(resource[:size])
     when :ec

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -15,15 +15,15 @@ Puppet::Type.newtype(:ssl_pkey) do
   end
 
   newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa', 'dsa or ec'"
-    newvalues :rsa, :dsa, :ec
+    desc 'The authentication algorithm'
+    newvalues :rsa, :ec
     defaultto :rsa
 
     munge(&:to_sym)
   end
 
   newparam(:size) do
-    desc 'The key size'
+    desc 'The key size for RSA keys'
     newvalues %r{\d+}
     defaultto 2048
 

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -50,7 +50,7 @@ describe 'The openssl provider for the ssl_pkey type' do
   end
 
   context 'when setting authentication to rsa' do
-    it 'creates a dsa key' do
+    it 'creates an rsa key' do
       resource[:authentication] = :rsa
       allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
@@ -72,36 +72,6 @@ describe 'The openssl provider for the ssl_pkey type' do
         resource[:authentication] = :rsa
         resource[:password] = '2x$5{'
         allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
-        expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
-        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
-        resource.provider.create
-      end
-    end
-  end
-
-  context 'when setting authentication to dsa' do
-    it 'creates a dsa key' do
-      resource[:authentication] = :dsa
-      allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
-      expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
-      resource.provider.create
-    end
-
-    context 'when setting size' do
-      it 'creates with given size' do
-        resource[:authentication] = :dsa
-        resource[:size] = 1024
-        allow(OpenSSL::PKey::DSA).to receive(:new).with(1024).and_return(key)
-        expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
-        resource.provider.create
-      end
-    end
-
-    context 'when setting password' do
-      it 'creates with given password' do
-        resource[:authentication] = :dsa
-        resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::DSA).to receive(:new).with(2048).and_return(key)
         expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create

--- a/spec/unit/puppet/type/ssl_pkey_spec.rb
+++ b/spec/unit/puppet/type/ssl_pkey_spec.rb
@@ -35,8 +35,6 @@ describe Puppet::Type.type(:ssl_pkey) do
   it 'accepts a valid authentication' do
     resource[:authentication] = :rsa
     expect(resource[:authentication]).to eq(:rsa)
-    resource[:authentication] = :dsa
-    expect(resource[:authentication]).to eq(:dsa)
     resource[:authentication] = :ec
     expect(resource[:authentication]).to eq(:ec)
   end


### PR DESCRIPTION
DSA is considered insecure by now. FIPS 186-5 forbids signing with DSA and on modern distributions have started to drop support for it.