### PR TITLE
Support OpenSSL 3

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
     when :rsa
       OpenSSL::PKey::RSA.new(resource[:size])
     when :ec
-      OpenSSL::PKey::EC.new(resource[:curve]).generate_key
+      OpenSSL::PKey::EC.generate(resource[:curve])
     else
       raise Puppet::Error,
             "Unknown authentication type '#{resource[:authentication]}'"

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -8,7 +8,6 @@ describe 'The openssl provider for the ssl_pkey type' do
   let(:path) { '/tmp/foo.key' }
   let(:pathname) { Pathname.new(path) }
   let(:resource) { Puppet::Type::Ssl_pkey.new(path: path) }
-  let(:key) { OpenSSL::PKey::RSA.new }
 
   it 'exists? should return true if key exists' do
     expect(Pathname).to receive(:new).twice.with(path).and_return(pathname)
@@ -24,7 +23,7 @@ describe 'The openssl provider for the ssl_pkey type' do
 
   context 'when creating a key with defaults' do
     it 'creates an rsa key' do
-      allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+      expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -32,7 +31,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting size' do
       it 'creates with given size' do
         resource[:size] = 1024
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
+        expect(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -41,7 +40,7 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting password' do
       it 'creates with given password' do
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+        expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_call_original
         expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
@@ -52,7 +51,7 @@ describe 'The openssl provider for the ssl_pkey type' do
   context 'when setting authentication to rsa' do
     it 'creates an rsa key' do
       resource[:authentication] = :rsa
-      allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+      expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -61,7 +60,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given size' do
         resource[:authentication] = :rsa
         resource[:size] = 1024
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_return(key)
+        expect(OpenSSL::PKey::RSA).to receive(:new).with(1024).and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -71,7 +70,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:authentication] = :rsa
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(key)
+        expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_call_original
         expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
@@ -80,11 +79,9 @@ describe 'The openssl provider for the ssl_pkey type' do
   end
 
   context 'when setting authentication to ec' do
-    key = OpenSSL::PKey::EC.new('secp384r1').generate_key # For mocking
-
     it 'creates an ec key' do
       resource[:authentication] = :ec
-      allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
+      allow(OpenSSL::PKey::EC).to receive(:generate).with('secp384r1').and_call_original
       expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
       resource.provider.create
     end
@@ -92,8 +89,9 @@ describe 'The openssl provider for the ssl_pkey type' do
     context 'when setting curve' do
       it 'creates with given curve' do
         resource[:authentication] = :ec
-        resource[:curve] = 'prime239v1'
-        allow(OpenSSL::PKey::EC).to receive(:new).with('prime239v1').and_return(key)
+        # See: openssl ecparam -list_curves
+        resource[:curve] = 'prime256v1'
+        expect(OpenSSL::PKey::EC).to receive(:generate).with('prime256v1').and_call_original
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create
       end
@@ -103,7 +101,7 @@ describe 'The openssl provider for the ssl_pkey type' do
       it 'creates with given password' do
         resource[:authentication] = :ec
         resource[:password] = '2x$5{'
-        allow(OpenSSL::PKey::EC).to receive(:new).with('secp384r1').and_return(key)
+        expect(OpenSSL::PKey::EC).to receive(:generate).with('secp384r1').and_call_original
         expect(OpenSSL::Cipher).to receive(:new).with('aes-256-cbc')
         expect(File).to receive(:write).with('/tmp/foo.key', kind_of(String))
         resource.provider.create


### PR DESCRIPTION
In OpenSSL 3 the `OpenSSL::PKey::EC` class has become immutable. In a pure OpenSSL 3 world the right thing would be to use `OpenSSL::PKey.generate_key` but that's not supported in OpenSSL 1.  Calling `.generate` is compatible with both 1 and 3.

It also stops mocking the actual calls to see if they will work. prime239v1 is replaced by prime256v1 because on Fedora 39+ only the latter is available.

I only tested this locally on my desktop. If it passes, it's a pure enhancement and I'd expect make Puppet 8 support possible.