### PR TITLE
Pass openssl commands as an array

### DIFF
--- a/manifests/export/pem_key.pp
+++ b/manifests/export/pem_key.pp
@@ -26,23 +26,21 @@ define openssl::export::pem_key (
 ) {
   if $ensure == 'present' {
     $passin_opt = $in_pass ? {
-      undef   => '',
-      default => "-passin pass:${shellquote($in_pass)}",
+      undef   => [],
+      default => ['-passin', "pass:${in_pass}"],
     }
 
     $passout_opt = $out_pass ? {
-      undef   => '-nodes',
-      default => "-passout pass:${shellquote($out_pass)}",
+      undef   => ['-nodes'],
+      default => ['-passout', "pass:${out_pass}"],
     }
 
     $cmd = [
-      'openssl pkcs12',
-      "-in ${pfx_cert}",
-      "-out ${pem_key}",
+      'openssl', 'pkcs12',
+      '-in', $pfx_cert,
+      '-out', $pem_key,
       '-nocerts',
-      $passin_opt,
-      $passout_opt,
-    ]
+    ] + $passin_opt + $passout_opt
 
     if $dynamic {
       $exec_params = {
@@ -54,7 +52,7 @@ define openssl::export::pem_key (
     }
 
     exec { "Export ${pfx_cert} to ${pem_key}":
-      command => inline_template('<%= @cmd.join(" ") %>'),
+      command => $cmd,
       path    => $facts['path'],
       *       => $exec_params,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -86,7 +86,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 7.9.0 < 9.0.0"
     }
   ]
 }

--- a/spec/defines/openssl_export_pem_cert_spec.rb
+++ b/spec/defines/openssl_export_pem_cert_spec.rb
@@ -42,7 +42,7 @@ describe 'openssl::export::pem_cert' do
 
     it {
       is_expected.to contain_exec('Export /etc/ssl/certs/foo.pfx to /etc/ssl/certs/foo.pem').with(
-        command: 'openssl pkcs12  -in /etc/ssl/certs/foo.pfx -out /etc/ssl/certs/foo.pem ',
+        command: ['openssl', 'pkcs12', '-in', '/etc/ssl/certs/foo.pfx', '-out', '/etc/ssl/certs/foo.pem'],
         creates: '/etc/ssl/certs/foo.pem',
         path: '/usr/bin:/bin:/usr/sbin:/sbin'
       )
@@ -60,7 +60,7 @@ describe 'openssl::export::pem_cert' do
 
     it {
       is_expected.to contain_exec('Export /etc/ssl/certs/foo.pfx to /etc/ssl/certs/foo.pem').with(
-        command: 'openssl pkcs12  -in /etc/ssl/certs/foo.pfx -out /etc/ssl/certs/foo.pem ',
+        command: ['openssl', 'pkcs12', '-in', '/etc/ssl/certs/foo.pfx', '-out', '/etc/ssl/certs/foo.pem'],
         path: '/usr/bin:/bin:/usr/sbin:/sbin',
         refreshonly: true
       )
@@ -79,7 +79,7 @@ describe 'openssl::export::pem_cert' do
 
     it {
       is_expected.to contain_exec('Export /etc/ssl/certs/foo.pfx to /etc/ssl/certs/foo.pem').with(
-        command: "openssl pkcs12  -in /etc/ssl/certs/foo.pfx -out /etc/ssl/certs/foo.pem -nokeys -passin pass:'5r$}^'",
+        command: ['openssl', 'pkcs12', '-in', '/etc/ssl/certs/foo.pfx', '-out', '/etc/ssl/certs/foo.pem', '-nokeys', '-passin', 'pass:5r$}^'],
         creates: '/etc/ssl/certs/foo.pem',
         path: '/usr/bin:/bin:/usr/sbin:/sbin'
       )
@@ -96,7 +96,7 @@ describe 'openssl::export::pem_cert' do
 
     it {
       is_expected.to contain_exec('Export /etc/ssl/certs/foo.der to /etc/ssl/certs/foo.pem').with(
-        command: 'openssl x509 -inform DER -in /etc/ssl/certs/foo.der -out /etc/ssl/certs/foo.pem ',
+        command: ['openssl', 'x509', '-inform', 'DER', '-in', '/etc/ssl/certs/foo.der', '-out', '/etc/ssl/certs/foo.pem'],
         creates: '/etc/ssl/certs/foo.pem',
         path: '/usr/bin:/bin:/usr/sbin:/sbin'
       )


### PR DESCRIPTION
Puppet 7.9 introduced support to pass an array, which avoids using a shell altogether. This simplifies the code because there's no more need to escape and join options.