### PR TITLE
fix: remove `nokeys` option and set default empty import/export passwords

### DIFF
--- a/examples/export_pkc12_from_key.pp
+++ b/examples/export_pkc12_from_key.pp
@@ -1,7 +1,7 @@
 include openssl
 openssl::export::pkcs12 { 'export.pkcs12':
-  ensure   => 'present',
-  basedir  => '/tmp',
-  pkey     => '/tmp/private.key',
-  cert     => '/tmp/cert.crt',
+  ensure  => 'present',
+  basedir => '/tmp',
+  pkey    => '/tmp/private.key',
+  cert    => '/tmp/cert.crt',
 }

--- a/examples/export_pkc12_from_key.pp
+++ b/examples/export_pkc12_from_key.pp
@@ -1,0 +1,7 @@
+include openssl
+openssl::export::pkcs12 { 'export.pkcs12':
+  ensure   => 'present',
+  basedir  => '/tmp',
+  pkey     => '/tmp/private.key',
+  cert     => '/tmp/cert.crt',
+}

--- a/examples/generate_cert_from_key.pp
+++ b/examples/generate_cert_from_key.pp
@@ -1,27 +1,27 @@
 include openssl
 
-file {'/tmp/template.cnf':
-  ensure   => file,
+file { '/tmp/template.cnf':
+  ensure  => file,
   content => epp('openssl/cert.cnf', {
-  	   'country' => 'de',
-	   'state'   => 'BW',
-	   'locality'=> 'undef',
-	   'organization'=> 'voxpupuli',
-	   'unit'        => 'anybody',
-	   'commonname'  => 'testpipeline.voxpupuli.org',
-	   'email'       => 'do_not_reply@voxpupuli.org',
-	   'default_bits'=> 4096,
-	   'default_md'  => 'sha256',
-	   'default_keyfile' => '/tmp/private.key',
-	   'basicconstraints' => ['CA:false'],
-	   'extendedkeyusages' => ['serverAuth'],
-	   'keyusages' => ['critical'],
-	   'subjectaltnames' => ['cert.voxpupuli.org', 'foo.bar.de'],
-	   })
+      'country'           => 'de',
+      'state'             => 'BW',
+      'locality'          => 'undef',
+      'organization'      => 'voxpupuli',
+      'unit'              => 'anybody',
+      'commonname'        => 'testpipeline.voxpupuli.org',
+      'email'             => 'do_not_reply@voxpupuli.org',
+      'default_bits'      => 4096,
+      'default_md'        => 'sha256',
+      'default_keyfile'   => '/tmp/private.key',
+      'basicconstraints'  => ['CA:false'],
+      'extendedkeyusages' => ['serverAuth'],
+      'keyusages'         => ['critical'],
+      'subjectaltnames'   => ['cert.voxpupuli.org', 'foo.bar.de'],
+  }),
 }
 
 x509_cert { '/tmp/cert.crt':
-    ensure => present,
-    private_key => '/tmp/private.key',
-    template => '/tmp/template.cnf',
+  ensure      => present,
+  private_key => '/tmp/private.key',
+  template    => '/tmp/template.cnf',
 }

--- a/examples/generate_cert_from_key.pp
+++ b/examples/generate_cert_from_key.pp
@@ -1,0 +1,27 @@
+include openssl
+
+file {'/tmp/template.cnf':
+  ensure   => file,
+  content => epp('openssl/cert.cnf', {
+  	   'country' => 'de',
+	   'state'   => 'BW',
+	   'locality'=> 'undef',
+	   'organization'=> 'voxpupuli',
+	   'unit'        => 'anybody',
+	   'commonname'  => 'testpipeline.voxpupuli.org',
+	   'email'       => 'do_not_reply@voxpupuli.org',
+	   'default_bits'=> 4096,
+	   'default_md'  => 'sha256',
+	   'default_keyfile' => '/tmp/private.key',
+	   'basicconstraints' => ['CA:false'],
+	   'extendedkeyusages' => ['serverAuth'],
+	   'keyusages' => ['critical'],
+	   'subjectaltnames' => ['cert.voxpupuli.org', 'foo.bar.de'],
+	   })
+}
+
+x509_cert { '/tmp/cert.crt':
+    ensure => present,
+    private_key => '/tmp/private.key',
+    template => '/tmp/template.cnf',
+}

--- a/examples/generate_key.pp
+++ b/examples/generate_key.pp
@@ -2,4 +2,3 @@ contain openssl
 ssl_pkey { '/tmp/private.key':
   ensure => present,
 }
-

--- a/examples/generate_key.pp
+++ b/examples/generate_key.pp
@@ -1,0 +1,5 @@
+contain openssl
+ssl_pkey { '/tmp/private.key':
+  ensure => present,
+}
+

--- a/examples/generate_pem_key.pp
+++ b/examples/generate_pem_key.pp
@@ -1,0 +1,6 @@
+include openssl
+openssl::export::pem_key { 'key-UUID':
+  ensure => present,
+  pfx_cert => '/tmp/export.pkcs12.p12',
+  pem_key => '/tmp/key.pem'
+}

--- a/examples/generate_pem_key.pp
+++ b/examples/generate_pem_key.pp
@@ -1,6 +1,6 @@
 include openssl
 openssl::export::pem_key { 'key-UUID':
-  ensure => present,
+  ensure   => present,
   pfx_cert => '/tmp/export.pkcs12.p12',
-  pem_key => '/tmp/key.pem'
+  pem_key  => '/tmp/key.pem',
 }

--- a/examples/x509_pkcs12_pemkey.pp
+++ b/examples/x509_pkcs12_pemkey.pp
@@ -1,9 +1,10 @@
 contain openssl
 
 openssl::certificate::x509 { 'sample_x509':
-  ensure   => present,
-  base_dir => '/tmp',
-  key_size => 1024, #entropy in CI is limited
+  ensure       => present,
+  base_dir     => '/tmp',
+  key_size     => 1024, #entropy in CI is limited
+  organization => 'voxpupuli',
 }
 
 openssl::export::pkcs12 { 'export.pkcs12':

--- a/examples/x509_pkcs12_pemkey.pp
+++ b/examples/x509_pkcs12_pemkey.pp
@@ -1,0 +1,20 @@
+contain openssl
+
+openssl::certificate::x509 { 'sample_x509':
+  ensure   => present,
+  base_dir => '/tmp',
+  key_size => 1024, #entropy in CI is limited
+}
+
+openssl::export::pkcs12 { 'export.pkcs12':
+  ensure  => 'present',
+  basedir => '/tmp',
+  pkey    => '/tmp/sample_x509.key',
+  cert    => '/tmp/sample_x509.crt',
+}
+
+openssl::export::pem_key { 'key-UUID':
+  ensure   => present,
+  pfx_cert => '/tmp/export.pkcs12.p12',
+  pem_key  => '/tmp/key.pem',
+}

--- a/manifests/export/pem_key.pp
+++ b/manifests/export/pem_key.pp
@@ -26,18 +26,18 @@ define openssl::export::pem_key (
 ) {
   if $ensure == 'present' {
     if $in_pass {
-      $passin_opt = ['-nokeys', '-passin', 'env:CERTIFICATE_PASSIN']
+      $passin_opt = ['-passin', 'env:CERTIFICATE_PASSIN']
       $passin_env = ["CERTIFICATE_PASSIN=${in_pass}"]
     } else {
-      $passin_opt = []
+      $passin_opt = ['-passin', 'pass:']
       $passin_env = []
     }
 
     if $out_pass {
-      $passout_opt = ['-nokeys', '-passout', 'env:CERTIFICATE_PASSOUT']
+      $passout_opt = ['-passout', 'env:CERTIFICATE_PASSOUT']
       $passout_env = ["CERTIFICATE_PASSOUT=${out_pass}"]
     } else {
-      $passout_opt = []
+      $passout_opt = ['-nodes']
       $passout_env = []
     }
 

--- a/manifests/export/pkcs12.pp
+++ b/manifests/export/pkcs12.pp
@@ -34,18 +34,18 @@ define openssl::export::pkcs12 (
 
   if $ensure == 'present' {
     if $in_pass {
-      $passin_opt = ['-nokeys', '-passin', 'env:CERTIFICATE_PASSIN']
+      $passin_opt = ['-passin', 'env:CERTIFICATE_PASSIN']
       $passin_env = ["CERTIFICATE_PASSIN=${in_pass}"]
     } else {
-      $passin_opt = []
+      $passin_opt = ['-passin', 'pass:']
       $passin_env = []
     }
 
     if $out_pass {
-      $passout_opt = ['-nokeys', '-passout', 'env:CERTIFICATE_PASSOUT']
+      $passout_opt = ['-passout', 'env:CERTIFICATE_PASSOUT']
       $passout_env = ["CERTIFICATE_PASSOUT=${out_pass}"]
     } else {
-      $passout_opt = []
+      $passout_opt = ['-passout', 'pass:']
       $passout_env = []
     }
 

--- a/spec/acceptance/x509_pkcs12.rb
+++ b/spec/acceptance/x509_pkcs12.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+# the openssl output changed and differs between EL9 vs older versions
+# https://github.com/mizzy/serverspec/commit/ac366dd40015f0b53e70a3ed881b931dfc83c603 might not be a correct fix
+# Ewoud is working on a fix in https://github.com/ekohl/serverspec/commit/64874e9c8cc70b097300c3a60281572a3528768e
+# in the meantime we won't use x509_certificate matcher
+describe 'x509 to pkcs12 to pem key' do
+  it_behaves_like 'the example', 'x509_pkcs12_pemkey.pp' do
+    it { expect(file('/tmp/sample_x509.crt')).to be_file.and(have_attributes(owner: 'root')) }
+    # it { expect(x509_certificate('/tmp/foo.example.com.crt')).to be_certificate.and(have_attributes(subject: 'C = CH, O = Example.com, CN = foo.example.com')) }
+
+    describe x509_certificate('/tmp/sample_x509.crt') do
+      it { is_expected.to be_certificate }
+      it { is_expected.to be_valid }
+      #      its(:subject) { is_expected.to match_without_whitespace(%r{C = CH, O = Example.com, CN = foo.example.com}) }
+      its(:keylength) { is_expected.to eq 1024 }
+    end
+
+    #    it { expect(file('/tmp/foo.example.com.key')).to be_file.and(have_attributes(owner: 'nobody', mode: '600')) }
+    #    it { expect(x509_private_key('/tmp/foo.example.com.key', passin: 'pass:mahje1Qu')).to have_matching_certificate('/tmp/foo.example.com.crt') }
+  end
+end

--- a/spec/acceptance/x509_pkcs12_spec.rb
+++ b/spec/acceptance/x509_pkcs12_spec.rb
@@ -8,17 +8,18 @@ require 'spec_helper_acceptance'
 # in the meantime we won't use x509_certificate matcher
 describe 'x509 to pkcs12 to pem key' do
   it_behaves_like 'the example', 'x509_pkcs12_pemkey.pp' do
-    it { expect(file('/tmp/sample_x509.crt')).to be_file.and(have_attributes(owner: 'root')) }
-    # it { expect(x509_certificate('/tmp/foo.example.com.crt')).to be_certificate.and(have_attributes(subject: 'C = CH, O = Example.com, CN = foo.example.com')) }
+    it { expect(file('/tmp/sample_x509.crt')).to be_file.and(its(:size) { is_expected.to > 0 }) }
+    it { expect(file('/tmp/sample_x509.key')).to be_file.and(its(:size) { is_expected.to > 0 }) }
+    it { expect(file('/tmp/export.pkcs12.p12')).to be_file.and(its(:size) { is_expected.to > 0 }) }
 
     describe x509_certificate('/tmp/sample_x509.crt') do
       it { is_expected.to be_certificate }
       it { is_expected.to be_valid }
-      #      its(:subject) { is_expected.to match_without_whitespace(%r{C = CH, O = Example.com, CN = foo.example.com}) }
       its(:keylength) { is_expected.to eq 1024 }
     end
 
-    #    it { expect(file('/tmp/foo.example.com.key')).to be_file.and(have_attributes(owner: 'nobody', mode: '600')) }
-    #    it { expect(x509_private_key('/tmp/foo.example.com.key', passin: 'pass:mahje1Qu')).to have_matching_certificate('/tmp/foo.example.com.crt') }
+    describe command('openssl -text -noout -in /tmp/export.pkcs12.p12 -inpass pass:') do
+      its(:exit_status) { is_expected.to eq 0 }
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

After changes in 4.1.0 the private key import/export into p12 files stopped working properly. The nokeys option in p12 export omits the private key. 

Additionally the possibility to handle empty passwords was modified and is no longer working, OpenSSL claims about missing export/import passphrases.


#### This Pull Request (PR) fixes the following issues

Fixes #132 

